### PR TITLE
Skip creating content nodes of non-existent or removed YouTube videos

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 le-utils==0.0.9rc23
 ricecooker>=0.6.0
+youtube-dl>=2017.6.25


### PR DESCRIPTION
Fixes https://github.com/learningequality/ricecooker/issues/94

Thanks @ivanistheone for suggesting the fix

Tested by running `./te_chef.py -v --reset --token=... --stage` and verifying that one of the videos that's been removed, http://www.touchableearth.org/india-family-aadits-room, doesn't show up in contentworkshop.le.org. Also, verify that there are no youtube-dl error logs that are emitted by ricecooker (during the downloading of the content tree).

Review @ivanistheone or @jamalex (or someone else?)