### PR TITLE
Download subtitles in available languages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 le-utils==0.0.9rc23
 ricecooker>=0.6.0
 youtube-dl>=2017.6.25
+pycountry>=17.5.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 le-utils==0.0.9rc23
 ricecooker>=0.6.0
 youtube-dl>=2017.6.25
-iso-639==0.4.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 le-utils==0.0.9rc23
 ricecooker>=0.6.0
 youtube-dl>=2017.6.25
+iso-639==0.4.5

--- a/te_chef.py
+++ b/te_chef.py
@@ -215,7 +215,7 @@ def scrape_content(title, content_url):
                 # form as returned from youtube-dl in order to actually be able
                 # to download that language from YouTube.
                 #
-                # TODO(david): Make a change in Ricecooker so that we can
+                # TODO(davidhu): Make a change in Ricecooker so that we can
                 # resolve this issue. As of July 10, 2017, about 13 subtitles
                 # don't get downloaded due to this issue.
                 print("      WARNING: subtitle language %s not found in languages"
@@ -294,7 +294,7 @@ def get_youtube_id_from_url(value):
 
 
 # This is taken and modified from https://github.com/fle-internal/sushi-chef-ck12/blob/cb0d538b6857f399271d0895967727f635e58ee0/chef.py#L85
-# TODO(david): Extract to a util library
+# TODO(davidhu): Extract to a util library
 def make_request(url, clear_cookies=True, timeout=60, *args, **kwargs):
     if clear_cookies:
         sess.cookies.clear()


### PR DESCRIPTION
... as determined from youtube-dl (thanks @ivanistheone for that suggestion!)

Addresses #3 

Review please, @ivanistheone or @jamalex 

cc @laurenlichtman 

## Test plan

**Test that this downloads all subtitles for a given video:**

- look at the [China > Family > Apple's Family](http://www.touchableearth.org/china-family-apples-family/) video on Touchable Earth, see that it currently has English and French as (human generated) subtitles
- look at the corresponding video on the content workshop and see that it also has English and French as subtitles

**Test that this only downloads human-generated subtitles and no auto-generated ones:**

- look at the [China > Facts > Welcome](http://www.touchableearth.org/china-facts-welcome/) video on the TE site, see that it has Italian as an auto-generated subtitle language and English as a human-generated subtitle language (via Dotsub)
- check the corresponding video on Content Workshop and see that it only has English as a subtitle

Also the youtube-dl Python docs (accessible via `import youtube_dl; help(youtube_dl)` in iPython) seem to indicate that another parameter — in addition to the ones included in this diff — may need to be included to download automatic subtitles:

```
     |  writesubtitles:    Write the video subtitles to a file
     |  writeautomaticsub: Write the automatically generated subtitles to a file
     |  allsubtitles:      Downloads all the subtitles of the video
     |                     (requires writesubtitles or writeautomaticsub)
```

