### PR TITLE
Support for multiple languages, starting with French!

### DIFF
--- a/te_chef.py
+++ b/te_chef.py
@@ -316,6 +316,10 @@ def scrape_content(title, content_url):
         youtube_url = doc.select_one(".video-container iframe")["src"]
         youtube_id = get_youtube_id_from_url(youtube_url)
 
+        if not youtube_id:
+            print("    *** WARNING: youtube_id not found for content url", content_url)
+            return None
+
         try:
             info = ydl.extract_info(youtube_url, download=False)
             subtitles = info.get("subtitles")

--- a/te_chef.py
+++ b/te_chef.py
@@ -316,6 +316,8 @@ def scrape_content(title, content_url):
         youtube_url = doc.select_one(".video-container iframe")["src"]
         youtube_id = get_youtube_id_from_url(youtube_url)
 
+        print("Youtube ID is", youtube_id)
+
         if not youtube_id:
             print("    *** WARNING: youtube_id not found for content url", content_url)
             return None
@@ -470,8 +472,8 @@ if __name__ == '__main__':
     """
     This code will run when the sushi chef is called from the command line.
     """
-    print("----- Scraping Touchable Earth English channel! -----\n\n")
-    EnglishChef().main()
+    #print("----- Scraping Touchable Earth English channel! -----\n\n")
+    #EnglishChef().main()
 
     print("----- Scraping Touchable Earth French channel! -----\n\n")
     FrenchChef().main()

--- a/te_chef.py
+++ b/te_chef.py
@@ -449,8 +449,6 @@ def make_request(url, clear_cookies=True, timeout=60, *args, **kwargs):
     if response.status_code != 200:
         print("NOT FOUND:", url)
         return None
-    #elif not response.from_cache:
-        #print("NOT CACHED:", url)
 
     return response
 

--- a/te_chef.py
+++ b/te_chef.py
@@ -70,7 +70,7 @@ class TouchableEarthChef(SushiChef):
 class EnglishChef(TouchableEarthChef):
     channel_info = {
         'CHANNEL_SOURCE_DOMAIN': "www.touchableearth.org",
-        'CHANNEL_SOURCE_ID': "touchable-earth-english",
+        'CHANNEL_SOURCE_ID': "touchable-earth",
         'CHANNEL_TITLE': "Touchable Earth",
         'CHANNEL_THUMBNAIL': "https://d1iiooxwdowqwr.cloudfront.net/pub/appsubmissions/20140218003206_PROFILEPHOTO.jpg",
         'CHANNEL_LANGUAGE': 'en',

--- a/te_chef.py
+++ b/te_chef.py
@@ -316,10 +316,9 @@ def scrape_content(title, content_url):
         youtube_url = doc.select_one(".video-container iframe")["src"]
         youtube_id = get_youtube_id_from_url(youtube_url)
 
-        print("Youtube ID is", youtube_id)
-
         if not youtube_id:
             print("    *** WARNING: youtube_id not found for content url", content_url)
+            print("    Skipping.")
             return None
 
         try:

--- a/te_chef.py
+++ b/te_chef.py
@@ -57,27 +57,16 @@ class TouchableEarthChef(SushiChef):
     We'll call its `main()` method from the command line script.
     """
     # XXX how to make sure we can't instantiate raw class of this type?
-    # XXX subclasses must define: channel_info and language
-
-    def __init__(self, language="en", **kwargs):
-        super(TouchableEarthChef, self).__init__(**kwargs)
-
+    # XXX subclasses must define: channel_info
     def construct_channel(self, **kwargs):
         """
         Create ChannelNode and build topic tree.
         """
         # create channel
-        channel_info = self.channel_info
-        channel = nodes.ChannelNode(
-            source_domain = channel_info['CHANNEL_SOURCE_DOMAIN'],
-            source_id = channel_info['CHANNEL_SOURCE_ID'],
-            title = channel_info['CHANNEL_TITLE'],
-            thumbnail = channel_info.get('CHANNEL_THUMBNAIL'),
-            description = channel_info.get('CHANNEL_DESCRIPTION'),
-        )
+        channel = self.get_channel()
 
         # build tree
-        add_countries_to_channel(channel, self.language)
+        add_countries_to_channel(channel, channel.language)
 
         return channel
 
@@ -88,8 +77,9 @@ class FrenchChef(TouchableEarthChef):
         'CHANNEL_SOURCE_ID': "touchable-earth-french",
         'CHANNEL_TITLE': "Touchable Earth (fr)",
         'CHANNEL_THUMBNAIL': "https://d1iiooxwdowqwr.cloudfront.net/pub/appsubmissions/20140218003206_PROFILEPHOTO.jpg",
+        'CHANNEL_LANGUAGE': 'fr',
+        'CHANNEL_DESCRIPTION': 'Where kids teach kids about the world. Taught entirely by school age children in short videos, Touchable Earth promotes tolerance for gender, culture, and identity.',
     }
-    language = "fr"
 
 
 def add_countries_to_channel(channel, language):

--- a/te_chef.py
+++ b/te_chef.py
@@ -471,8 +471,8 @@ if __name__ == '__main__':
     """
     This code will run when the sushi chef is called from the command line.
     """
-    #print("----- Scraping Touchable Earth English channel! -----\n\n")
-    #EnglishChef().main()
+    print("----- Scraping Touchable Earth English channel! -----\n\n")
+    EnglishChef().main()
 
     print("----- Scraping Touchable Earth French channel! -----\n\n")
     FrenchChef().main()

--- a/te_chef.py
+++ b/te_chef.py
@@ -46,7 +46,8 @@ sess.mount('http://www.touchableearth.org', forever_adapter)
 
 TE_LICENSE = licenses.SpecialPermissionsLicense(
     description="Permission has been granted by Touchable Earth to"
-    " distribute this content through Kolibri."
+    " distribute this content through Kolibri.",
+    copyright_holder="Touchable Earth Foundation (New Zealand)"
 )
 
 

--- a/te_chef.py
+++ b/te_chef.py
@@ -3,6 +3,7 @@
 """
 Sushi Chef for Touchable Earth: http://www.touchableearth.org/
 Consists of videos and images.
+Supports multiple languages -- just create another subclass of TouchableEarthChef!
 """
 
 import os
@@ -26,10 +27,6 @@ from ricecooker.utils.browser import preview_in_browser
 from ricecooker.utils.html import download_file
 from ricecooker.utils.zip import create_predictable_zip
 from ricecooker import config
-
-
-# XXX
-FRENCH = True
 
 
 sess = requests.Session()
@@ -56,20 +53,29 @@ class TouchableEarthChef(SushiChef):
     The chef class that takes care of uploading channel to the content curation server.
 
     We'll call its `main()` method from the command line script.
+
+    NOTE: Do no directly instantiate. This is an abstract base class.
+    Subclasses must provide the channel_info class property. See examples
+    below.
     """
-    # XXX how to make sure we can't instantiate raw class of this type?
-    # XXX subclasses must define: channel_info
     def construct_channel(self, **kwargs):
         """
         Create ChannelNode and build topic tree.
         """
-        # create channel
         channel = self.get_channel()
-
-        # build tree
         add_countries_to_channel(channel, channel.language)
-
         return channel
+
+
+class EnglishChef(TouchableEarthChef):
+    channel_info = {
+        'CHANNEL_SOURCE_DOMAIN': "www.touchableearth.org",
+        'CHANNEL_SOURCE_ID': "touchable-earth-english",
+        'CHANNEL_TITLE': "Touchable Earth",
+        'CHANNEL_THUMBNAIL': "https://d1iiooxwdowqwr.cloudfront.net/pub/appsubmissions/20140218003206_PROFILEPHOTO.jpg",
+        'CHANNEL_LANGUAGE': 'en',
+        'CHANNEL_DESCRIPTION': 'Where kids teach kids about the world. Taught entirely by school age children in short videos, Touchable Earth promotes tolerance for gender, culture, and identity.',
+    }
 
 
 class FrenchChef(TouchableEarthChef):
@@ -99,7 +105,6 @@ def scrape_country(title, country_url, language):
     title: China
     country_url: http://www.touchableearth.org/china-facts-welcome/?lang=fr
     """
-    # XXX indicate language
     print("Scraping country node: %s (%s)" % (title, country_url))
 
     doc = get_parsed_html_from_url(country_url)
@@ -463,5 +468,8 @@ if __name__ == '__main__':
     """
     This code will run when the sushi chef is called from the command line.
     """
-    chef = FrenchChef()
-    chef.main()
+    print("----- Scraping Touchable Earth English channel! -----\n\n")
+    EnglishChef().main()
+
+    print("----- Scraping Touchable Earth French channel! -----\n\n")
+    FrenchChef().main()

--- a/te_chef.py
+++ b/te_chef.py
@@ -96,7 +96,7 @@ def add_countries_to_channel(channel, language):
 def scrape_country(title, country_url, language):
     """
     title: China
-    country_url: http://www.touchableearth.org/china-facts-welcome/
+    country_url: http://www.touchableearth.org/china-facts-welcome/?lang=fr
     """
     # XXX indicate language
     print("Scraping country node: %s (%s)" % (title, country_url))
@@ -116,11 +116,21 @@ def add_topics_to_country(doc, country_node, language):
     country_url: http://www.touchableearth.org/china/
     """
     topic_options = doc.select(".sub_cat_dropdown .select_option_subcat option")
+    topic_urls_added = set()
+
     for option in topic_options:
         if option.has_attr("selected"):
             continue
+
         url = option["value"]
         title = option.text.strip()
+
+        # Skip duplicates
+        if url in topic_urls_added:
+            continue
+        else:
+            topic_urls_added.add(url)
+
         country_node.add_child(scrape_category(title, url, language))
 
 


### PR DESCRIPTION
This creates a separate channel for each additional language. Requested by @laurenlichtman , with consideration that we may want to support future languages that Touchable Earth gets translated into in the near future.

Add support for new languages by subclassing `TouchableEarthChef` and then instantiating and calling its `main()` in the script's `__main__`.

Currently running this on `vader`. Will update this PR with a link to the new French channel once it's uploaded.

Review please, @ivanistheone ?